### PR TITLE
ci(release): inline shared release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,12 +18,58 @@ on:
 jobs:
   publish:
     name: "Publish ${{ inputs.snapshot && 'beta' || 'stable' }}"
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ inputs.concurrency-group }}
+      cancel-in-progress: false
     permissions:
       contents: 'write'
       id-token: 'write'
       issues: 'write'
       pull-requests: 'write'
-    uses: hexadrop/github-workflows/.github/workflows/release.yml@v1
-    with:
-      snapshot: ${{ inputs.snapshot }}
-      concurrency-group: ${{ inputs.concurrency-group }}
+    outputs:
+      published: ${{ steps.changesets.outputs.published }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Generate beta snapshot
+        if: inputs.snapshot
+        run: bun changeset version --snapshot beta
+
+      - name: Publish beta to npm
+        if: inputs.snapshot
+        run: bun changeset publish --tag beta --no-git-tag
+
+      - name: Capture release version
+        if: ${{ !inputs.snapshot }}
+        run: |
+          bun changeset status --output=release.json
+          echo "NEW_VERSION=$(jq -r '.releases[0].newVersion' release.json)" >> "$GITHUB_ENV"
+          rm release.json
+
+      - name: Create Release Pull Request or Publish to npm
+        if: ${{ !inputs.snapshot }}
+        id: changesets
+        uses: changesets/action@v2.1.1
+        with:
+          publish-script: bun changeset publish
+          version-script: bun changeset version
+          commit-message: 'chore: release v${{env.NEW_VERSION}}'
+          pr-title: 'chore: release v${{env.NEW_VERSION}}'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Inlines the publish logic from `hexadrop/github-workflows/.github/workflows/release.yml@v1` into the local workflow so it can be adjusted independently.\n\n- Keeps `id-token: write` for npm Trusted Publisher.\n- Does not enable provenance (to be tested separately).