### PR TITLE
fix(release): always run changeset detector so main publishes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,6 @@ jobs:
 
   detect-changeset-change:
     name: Changeset
-    if: github.ref == 'refs/heads/develop'
     uses: hexadrop/github-workflows/.github/workflows/detect-changeset-change.yml@v1
 
   publish:


### PR DESCRIPTION
The `publish` job depends on `detect-changeset-change`. When that job was skipped on `main`, the publish job was also skipped because GitHub Actions skips downstream jobs when a needed job is skipped.\n\nThis change removes the `if: github.ref == 'refs/heads/develop'` condition from `detect-changeset-change` so it always runs. On `main` it will simply report no changeset changes, allowing the stable release to proceed.