### PR TITLE
chore: pin shared workflows to v1.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   check:
     name: Check
-    uses: hexadrop/github-workflows/.github/workflows/check.yml@v3
+    uses: hexadrop/github-workflows/.github/workflows/check.yml@v1.0.0
     with:
       commands: '["lint:ci", "typecheck"]'
       cache-commands: '["lint:ci"]'

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   check:
     name: Check
-    uses: hexadrop/github-workflows/.github/workflows/check.yml@v3
+    uses: hexadrop/github-workflows/.github/workflows/check.yml@v1.0.0
     with:
       commands: '["lint:ci", "typecheck"]'
       cache-commands: '["lint:ci"]'
@@ -15,6 +15,6 @@ jobs:
   release-prepare:
     name: Release
     needs: [ check ]
-    uses: hexadrop/github-workflows/.github/workflows/release-prepare.yml@v3
+    uses: hexadrop/github-workflows/.github/workflows/release-prepare.yml@v1.0.0
     with:
       base-branch: main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,14 +7,14 @@ on:
 jobs:
   check:
     name: Check
-    uses: hexadrop/github-workflows/.github/workflows/check.yml@v3
+    uses: hexadrop/github-workflows/.github/workflows/check.yml@v1.0.0
     with:
       commands: '["lint:ci", "typecheck"]'
       cache-commands: '["lint:ci"]'
 
   detect-changeset-change:
     name: Changeset
-    uses: hexadrop/github-workflows/.github/workflows/detect-changeset-change.yml@v3
+    uses: hexadrop/github-workflows/.github/workflows/detect-changeset-change.yml@v1.0.0
 
   publish:
     name: Publish
@@ -25,7 +25,7 @@ jobs:
       id-token: 'write'
       issues: 'write'
       pull-requests: 'write'
-    uses: hexadrop/github-workflows/.github/workflows/release.yml@v3
+    uses: hexadrop/github-workflows/.github/workflows/release.yml@v1.0.0
     with:
       snapshot: ${{ github.ref == 'refs/heads/develop' }}
       concurrency-group: release-${{ github.ref_name }}

--- a/.github/workflows/sync-to-develop.yml
+++ b/.github/workflows/sync-to-develop.yml
@@ -8,6 +8,6 @@ on:
 jobs:
   sync-to-develop:
     name: Sync to develop
-    uses: hexadrop/github-workflows/.github/workflows/sync-to-develop.yml@v3
+    uses: hexadrop/github-workflows/.github/workflows/sync-to-develop.yml@v1.0.0
     with:
       pr-title: 'chore: sync from {{main_branch}} to {{develop_branch}}'


### PR DESCRIPTION
Pins reusable workflows from `hexadrop/github-workflows` to the `v1.0.0` release.